### PR TITLE
fixed music stopping after game completion

### DIFF
--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -7,11 +7,21 @@ public class MainMenu : MonoBehaviour
 {
     public string mainScene;
 
+    public AudioSource musicSource;
+
     // Start is called before the first frame update
     void Start()
     {
         PauseMenuController.IsPaused = false;
         Cursor.visible = true;
+
+        musicSource = GameObject.Find("Music").GetComponent<AudioSource>();
+
+        if (!musicSource.isPlaying)
+        {
+            musicSource.volume = .08f;
+            musicSource.Play();
+        }
     }
 
     // Update is called once per frame


### PR DESCRIPTION
MusicCutoff.cs mutes and then turns off the main Music AudioSource, and never restarts it after boss/scoreboard. Fix adds reference to Music AudioSource in MainMenu.cs. Upon awake, checks if the AudioSource is playing, and if not, resets the volume of the source and also plays it.